### PR TITLE
Add support for Intel FPGA toolchain using Quartus

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -37,9 +37,11 @@ library:
   exposed-modules:
     - Clash.Shake
     - Clash.Shake.Xilinx
+    - Clash.Shake.Intel
 
 extra-source-files:
   - template/xilinx-ise/project.tcl.mustache
   - template/xilinx-vivado/project-build.tcl.mustache
   - template/xilinx-vivado/project.tcl.mustache
   - template/xilinx-vivado/upload.tcl.mustache
+  - template/intel-quartus/project.tcl.mustache

--- a/src/Clash/Shake/Intel.hs
+++ b/src/Clash/Shake/Intel.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE OverloadedStrings, RecordWildCards, TemplateHaskell #-}
+module Clash.Shake.Intel
+    ( IntelTarget(..), de0Nano
+    , intelQuartus
+    ) where
+
+import Clash.Shake
+
+import Development.Shake
+import Development.Shake.Command
+import Development.Shake.FilePath
+import Development.Shake.Config
+
+import Text.Mustache
+import qualified Text.Mustache.Compile.TH as TH
+import Data.Aeson
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.IO as T
+
+data IntelTarget = IntelTarget
+    { targetFamily :: String
+    , targetDevice :: String
+    , targetPackage :: String
+    , targetPin   :: String
+    , targetSpeed :: String
+    }
+
+targetMustache IntelTarget{..} =
+    [ "targetFamily"  .= T.pack targetFamily
+      , "targetDevice"  .= T.pack targetDevice
+      , "targetPackage" .= T.pack targetPackage
+      , "targetPin"     .= T.pack targetPin
+      , "targetSpeed"   .= T.pack targetSpeed
+      , "part"          .= T.pack (targetDevice <> targetPackage <> targetPin <> targetSpeed)
+    ]
+
+de0Nano :: IntelTarget
+de0Nano = IntelTarget "Cyclone IV E" "EP4CE22F17C6" "FBGA" "256" "6"
+
+intelQuartus :: IntelTarget -> ClashKit -> FilePath -> FilePath -> String -> Rules SynthKit
+intelQuartus fpga kit@ClashKit{..} outDir srcDir topName = do
+    let projectName = topName
+        rootDir = joinPath . map (const "..") . splitPath $ outDir
+
+    let quartus tool args = cmd_ (Cwd outDir) =<< toolchain "QUARTUS" tool args
+
+    let getFiles dir pats = getDirectoryFiles srcDir [ dir </> pat | pat <- pats ]
+        hdlSrcs = getFiles "src-hdl" ["*.vhdl", "*.v", "*.sv"]
+        tclSrcs = getFiles "src-hdl" ["*.tcl"]
+        constrSrcs = getFiles "src-hdl" ["*.sdc"]
+        ipCores = getFiles "ip" ["//*.qip"]
+
+    outDir <//> "*.tcl" %> \out -> do
+        srcs1 <- manifestSrcs
+        srcs2 <- hdlSrcs
+        tcls <- tclSrcs
+        constrs <- constrSrcs
+        cores <- ipCores
+
+        let template = $(TH.compileMustacheFile "template/intel-quartus/project.tcl.mustache")
+        let values = object . mconcat $
+                [ [ "project" .= T.pack projectName ]
+                  , [ "top" .= T.pack topName ]
+                  , targetMustache fpga
+                  , [ "srcs" .= mconcat
+                             [ [ object [ "fileName" .= (rootDir </> src) ] | src <- srcs1 ]
+                               , [ object [ "fileName" .= (rootDir </> srcDir </> src) ] | src <- srcs2 ]
+                             ]
+                    ]
+                  , [ "tclSrcs" .= [ object [ "fileName" .= (rootDir </> srcDir </> src) ] | src <- tcls ] ]
+                  , [ "ipcores" .= [ object [ "fileName" .= (rootDir </> srcDir </> core) ] | core <- cores ] ]
+                  , [ "constraintSrcs" .= [ object [ "fileName" .= (rootDir </> srcDir </> src) ] | src <- constrs ] ]
+                ]
+        writeFileChanged out . TL.unpack $ renderMustache template values
+
+    outDir </> "ip" <//> "*" %> \out -> do
+            let src = srcDir </> makeRelative outDir out
+            copyFileChanged src out
+
+    outDir </> topName <.> "sof" %> \_out -> do
+        srcs1 <- manifestSrcs
+        srcs2 <- hdlSrcs
+        cores <- ipCores
+        need $ mconcat
+            [ [ outDir </> projectName <.> "tcl" ]
+              , [ src | src <- srcs1 ]
+              , [ srcDir </> src | src <- srcs2 ]
+              , [ outDir </> core | core <- cores ]
+            ]
+        quartus "quartus_sh" ["-t", projectName <.> "tcl"]
+
+    return $ SynthKit
+        { bitfile = outDir </> topName <.> "sof"
+          , phonies =
+              [ "quartus" |> do
+                  need [outDir </> projectName <.> "tcl"]
+                  quartus "quartus_sh" ["-t", outDir </> projectName <.> "tcl"]
+              ]
+        }
+
+(|>) :: String -> Action () -> (String, Action ())
+(|>) = (,)

--- a/template/intel-quartus/project.tcl.mustache
+++ b/template/intel-quartus/project.tcl.mustache
@@ -1,0 +1,114 @@
+# Mustache template for Intel Quartus projects
+# for more details see: Quartus II Handbook Version 11.0 Volume 2
+# and Quartus II Scripting Reference Manual
+
+set myScript "{{project}}.tcl"
+
+# Load Quartus Prime Tcl Project packages
+package require ::quartus::project
+
+# Add the next line to get the execute_flow command
+package require ::quartus::flow
+
+set need_to_close_project 0
+set make_assignments 1
+
+# This procedure will open a quartus project
+proc Open {prj_name} {
+    global need_to_close_project
+    # Check that the right project is open
+    if {[is_project_open]} {
+        if {[string compare $quartus(project) $prj_name]} {
+            puts "Project is not open"
+            set make_assignments 0
+        }
+    } else {
+        # Only open if not already open
+        if {[project_exists $prj_name]} {
+            set current_revision [get_current_revision $prj_name]
+                project_open -revision $current_revision $prj_name
+        } else {
+            project_new -revision $prj_name $prj_name
+        }
+        set need_to_close_project 1
+    }
+}
+
+# This procedure adds files to quartus .qsf file
+proc Addfile {src_file {library "lib"} } {
+    if [regexp {.vhdl?$} $src_file] {
+        set_global_assignment -name VHDL_FILE "$src_file" -library "$library"
+    } elseif [regexp {.sv?$} $src_file] {
+        set_global_assignment -name SYSTEMVERILOG_FILE "$src_file" -library "$library"
+    } elseif [regexp {.v?$} $src_file] {
+        set_global_assignment -name VERILOG_FILE "$src_file" -library "$library"
+    } else {
+        puts "Unknown file type: $src_file"
+    }
+    # Commit assignments
+    export_assignments
+}
+
+# Open project
+Open "{{project}}"
+
+# Make assignments
+if {$make_assignments} {
+    set_global_assignment -name FAMILY "{{targetFamily}}"
+    set_global_assignment -name DEVICE "{{targetDevice}}"
+    set_global_assignment -name DEVICE_FILTER_PACKAGE {{targetPackage}}
+    set_global_assignment -name DEVICE_FILTER_PIN_COUNT {{targetPin}}
+    set_global_assignment -name DEVICE_FILTER_SPEED_GRADE {{targetSpeed}}
+    set_global_assignment -name PROJECT_OUTPUT_DIRECTORY "./"
+    set_global_assignment -name NUM_PARALLEL_PROCESSORS 2
+    set_global_assignment -name EDA_SIMULATION_TOOL "ModelSim-Altera (Verilog)"
+    set_global_assignment -name EDA_NETLIST_WRITER_OUTPUT_DIR ./netlist -section_id eda_simulation
+    set_global_assignment -name EDA_OUTPUT_DATA_FORMAT Verilog -section_id eda_simulation
+    set_global_assignment -name TIMEQUEST_MULTICORNER_ANALYSIS ON
+    set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
+    set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT -section_id Top
+    set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
+    set_global_assignment -name VERILOG_INPUT_VERSION SYSTEMVERILOG_2005
+    set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    set_global_assignment -name RESERVE_FLASH_NCE_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    set_global_assignment -name RESERVE_DATA0_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    set_global_assignment -name RESERVE_DATA1_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    set_global_assignment -name RESERVE_DCLK_AFTER_CONFIGURATION "USE AS REGULAR IO"
+    set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
+
+    # Setup top entity
+    set_global_assignment -name TOP_LEVEL_ENTITY "{{top}}"
+
+    # Source settings
+    {{#tclSrcs}}
+    source "{{fileName}}"
+    {{/tclSrcs}}
+
+    # Source constrains
+    {{#constraintSrcs}}
+    set_global_assignment -name SDC_FILE "{{fileName}}"
+    {{/constraintSrcs}}
+
+    puts "$myScript: Adding sources to project..."
+
+    # Add QIP files (from ip dir)
+    {{#ipcores}}
+    set_global_assignment -name QIP_FILE "{{fileName}}"
+    {{/ipcores}}
+
+    # Add sources to the project
+    {{#srcs}}
+    Addfile "{{fileName}}"
+    {{/srcs}}
+
+    # Commit assignments
+    export_assignments
+}
+
+execute_flow -compile
+
+# Close project
+if {$need_to_close_project} {
+    puts "Closing project"
+    project_close
+}


### PR DESCRIPTION
Hi Gergo,

I saw your presentation at Haskell Love Conference and I decided to port the Xilinx FPGA toolchain to Intel. I'm using it to run clash-pong example. Maybe it will serve as a starting point for further modifications.

This pull request contains changes for running clash-pong example on Intel FPGA.
Essentially this is a modified version of Xilinx.hs. It was tested on Quartus Prime 20.1. 

I hope you will find it useful. 