### PR TITLE
Add support for custom vivado version

### DIFF
--- a/src/Clash/Shake/Xilinx.hs
+++ b/src/Clash/Shake/Xilinx.hs
@@ -3,6 +3,7 @@ module Clash.Shake.Xilinx
     ( Target(..), targetPart
     , ise
     , vivado
+    , vivadoWithVersion
 
     , papilioPro, papilioOne, nexysA750T
     ) where
@@ -108,7 +109,10 @@ ise fpga kit@ClashKit{..} outDir srcDir topName = do
         }
 
 vivado :: Target -> ClashKit -> FilePath -> FilePath -> String -> Rules SynthKit
-vivado fpga kit@ClashKit{..} outDir srcDir topName = do
+vivado = vivadoWithVersion "2019"
+
+vivadoWithVersion :: String -> Target -> ClashKit -> FilePath -> FilePath -> String -> Rules SynthKit
+vivadoWithVersion version fpga kit@ClashKit{..} outDir srcDir topName = do
     let projectName = topName
         projectDir = outDir </> projectName
         xpr = projectDir </> projectName <.> "xpr"
@@ -156,6 +160,7 @@ vivado fpga kit@ClashKit{..} outDir srcDir topName = do
                        ]
                      , [ "ipcores" .= [ object [ "name" .= takeBaseName core ] | core <- cores ] ]
                      , [ "constraintSrcs" .= [ object [ "fileName" .= (srcDir </> src) ] | src <- constrs ] ]
+                     , [ "version" .= version ]
                      ]
         writeFileChanged out . TL.unpack $ renderMustache template values
 

--- a/template/xilinx-vivado/project.tcl.mustache
+++ b/template/xilinx-vivado/project.tcl.mustache
@@ -72,10 +72,10 @@ set_property -name "top_lib" -value "xil_defaultlib" -objects $obj
 
 # Create 'synth_1' run (if not found)
 if {[string equal [get_runs -quiet synth_1] ""]} {
-    create_run -name synth_1 -part {{part}} -flow {Vivado Synthesis 2019} -strategy "Vivado Synthesis Defaults" -report_strategy {No Reports} -constrset constrs_1
+    create_run -name synth_1 -part {{part}} -flow {Vivado Synthesis {{version}}} -strategy "Vivado Synthesis Defaults" -report_strategy {No Reports} -constrset constrs_1
 } else {
   set_property strategy "Vivado Synthesis Defaults" [get_runs synth_1]
-  set_property flow "Vivado Synthesis 2019" [get_runs synth_1]
+  set_property flow "Vivado Synthesis {{version}}" [get_runs synth_1]
 }
 set obj [get_runs synth_1]
 set_property set_report_strategy_name 1 $obj
@@ -97,10 +97,10 @@ current_run -synthesis [get_runs synth_1]
 
 # Create 'impl_1' run (if not found)
 if {[string equal [get_runs -quiet impl_1] ""]} {
-    create_run -name impl_1 -part {{part}} -flow {Vivado Implementation 2019} -strategy "Vivado Implementation Defaults" -report_strategy {No Reports} -constrset constrs_1 -parent_run synth_1
+    create_run -name impl_1 -part {{part}} -flow {Vivado Implementation {{version}}} -strategy "Vivado Implementation Defaults" -report_strategy {No Reports} -constrset constrs_1 -parent_run synth_1
 } else {
   set_property strategy "Vivado Implementation Defaults" [get_runs impl_1]
-  set_property flow "Vivado Implementation 2019" [get_runs impl_1]
+  set_property flow "Vivado Implementation {{version}}" [get_runs impl_1]
 }
 set obj [get_runs impl_1]
 set_property set_report_strategy_name 1 $obj


### PR DESCRIPTION
This change enables using clash-shake with vivado 2018.2.