### PR TITLE
Add Basys 3 Support

### DIFF
--- a/src/Clash/Shake/Xilinx.hs
+++ b/src/Clash/Shake/Xilinx.hs
@@ -5,7 +5,7 @@ module Clash.Shake.Xilinx
     , ise
     , vivado
 
-    , papilioPro, papilioOne, nexysA750T
+    , papilioPro, papilioOne, nexysA750T, basys3
     ) where
 
 import Clash.Shake
@@ -63,6 +63,10 @@ boardMustache Board{..} =
 nexysA750T :: Board
 nexysA750T = Board "digilentinc.com:nexys=a7-50t:part0:1.0" $
     Target "artix7" "xc7a50t" "csg324" 1
+
+basys3 :: Board
+basys3 = Board "digilentinc.com:basys3:part0:1.2" $
+    Target "artix7" "xc7a35t" "cpg236" 1
 
 
 ise :: Target -> ClashKit -> FilePath -> FilePath -> String -> Rules SynthKit


### PR DESCRIPTION
This PR has a corresponding PR to the clash-pong repo https://github.com/gergoerdi/clash-pong/pull/3

With these changes pong will build and run like a charm. 


**Update: I was actually able to build without suppressing the error. I probably just misconfigured the `basys3` expression in _Xilinx.hs_.**
 
~~But I had to add the following to both _template/xilinx-vivado/project-build.tcl.mustache_ and _template/xilinx-vivado/project.tcl.mustache_ to suppress some errors.~~
```
set_property SEVERITY {Warning} [get_drc_checks NSTD-1]
```

~~In particular, the errors output~~

~~**I'll get around to replicating this tomorrow**~~
