### PR TITLE
Add support for PYNQ-Z2 and uploading to Zynq

### DIFF
--- a/src/Clash/Shake/Xilinx.hs
+++ b/src/Clash/Shake/Xilinx.hs
@@ -5,7 +5,7 @@ module Clash.Shake.Xilinx
     , ise
     , vivado
 
-    , papilioPro, papilioOne, nexysA750T, basys3
+    , papilioPro, papilioOne, nexysA750T, basys3, pynqZ2
     ) where
 
 import Clash.Shake
@@ -29,10 +29,14 @@ data Target = Target
     , targetDevice :: String
     , targetPackage :: String
     , targetSpeed :: Word
+    , targetDeviceIndex :: Word
     }
 
 targetPart :: Target -> String
 targetPart Target{..} = targetDevice <> targetPackage <> "-" <> show targetSpeed
+
+targetDeviceName :: Target -> String
+targetDeviceName Target{..} = targetDevice <> "_" <> show targetDeviceIndex
 
 targetMustache :: Target -> [Aeson.Pair]
 targetMustache target@Target{..} =
@@ -41,13 +45,14 @@ targetMustache target@Target{..} =
     , "targetPackage" .= T.pack targetPackage
     , "targetSpeed"   .= targetSpeed
     , "part"          .= T.pack (targetPart target)
+    , "deviceName"    .= T.pack (targetDeviceName target)
     ]
 
 papilioPro :: Target
-papilioPro = Target "Spartan6" "xc6slx9" "tqg144" 2
+papilioPro = Target "Spartan6" "xc6slx9" "tqg144" 2 0
 
 papilioOne :: Target
-papilioOne = Target "Spartan3E" "xc3s500e" "vq100" 5
+papilioOne = Target "Spartan3E" "xc3s500e" "vq100" 5 0
 
 data Board = Board
     { boardSpec :: String -- TODO: what is the structure of this?
@@ -62,12 +67,15 @@ boardMustache Board{..} =
 
 nexysA750T :: Board
 nexysA750T = Board "digilentinc.com:nexys-a7-50t:part0:1.0" $
-    Target "artix7" "xc7a50t" "csg324" 1
+    Target "artix7" "xc7a50t" "csg324" 1 0
 
 basys3 :: Board
 basys3 = Board "digilentinc.com:basys3:part0:1.2" $
-    Target "artix7" "xc7a35t" "cpg236" 1
+    Target "artix7" "xc7a35t" "cpg236" 1 0
 
+pynqZ2 :: Board
+pynqZ2 = Board "tul.com.tw:pynq-z2:part0:1.0" $
+    Target "zynq7000" "xc7z020" "clg400" 1 1
 
 ise :: Target -> ClashKit -> FilePath -> FilePath -> String -> Rules SynthKit
 ise fpga kit@ClashKit{..} outDir srcDir topName = do

--- a/template/xilinx-vivado/upload.tcl.mustache
+++ b/template/xilinx-vivado/upload.tcl.mustache
@@ -2,7 +2,7 @@ open_hw
 connect_hw_server
 open_hw_target
 
-set devs [get_hw_devices {{targetDevice}}_0]
+set devs [get_hw_devices {{deviceName}}]
 set dev [lindex $devs 0]
 
 current_hw_device $devs


### PR DESCRIPTION
This changeset modifies `Xilinx.Target` to include `targetDeviceIndex`, in order to specify the index of the FPGA device in the chain when templating the `upload.tcl` script, which is required for Zynq devices where the ARM PS is the first device in the chain. 

Also adds a `pynqZ2` definition.