### PR TITLE
Add clashRulesWithTop to set a specific top entity and module

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                clash-shake
-version:             0.3.2
+version:             0.4.0
 category:            Hardware, Shake
 synopsis:            Shake rules for building Clash programs
 description: |

--- a/src/Clash/Shake.hs
+++ b/src/Clash/Shake.hs
@@ -8,6 +8,8 @@ module Clash.Shake
     , RunClash(..), ClashKit(..)
     , clashRules
     , SynthKit(..)
+    , findFiles
+    , SynthRules
 
     , binImage
 
@@ -139,6 +141,11 @@ data SynthKit = SynthKit
     { bitfile :: FilePath
     , phonies :: [(String, Action ())]
     }
+
+type SynthRules = ClashKit -> FilePath -> String -> Action [FilePath] -> Rules SynthKit
+
+findFiles :: [FilePath] -> [FilePattern] -> [FilePath]
+findFiles universe pats = filter (\fn -> (?== fn) `any` pats) universe
 
 nestedPhony :: String -> String -> Action () -> Rules ()
 nestedPhony target name = phony (target <> ":" <> name)


### PR DESCRIPTION
This changeset refactors out the logic of `clashRules` into a `clashRulesWithTop` function that allows specification of a top module and entrypoint. `clashRules` is kept with the same signature and heuristic to determine those extra arguments in the simple cases.

Specifically, I've found for my use case that the `isModuleName` heuristic doesn't work as I compile through stack, and I need the ability to set custom values for `clashTopName`.