### PR TITLE
Fix vivado phony target

### DIFF
--- a/src/Clash/Shake/Xilinx.hs
+++ b/src/Clash/Shake/Xilinx.hs
@@ -207,7 +207,7 @@ vivado board kit@ClashKit{..} outDir topName extraGenerated = do
         , phonies =
             [ "vivado" |> do
                    need [xpr]
-                   vivado "vivado" [xpr]
+                   vivado "vivado" [makeRelative outDir xpr]
             , "upload" |> do
                    need [projectDir </> projectName <.> "runs" </> "impl_1" </> topName <.> "bit"]
                    vivadoBatch "upload.tcl"


### PR DESCRIPTION
This fixes the path passed to Vivado to open the project. The existing code worked when supplied with absolute paths, but broke when supplied with relative paths as Vivado is already run from inside `outDir`, however `xpr` already includes `outDir`. This fix computes the correct relative path instead.